### PR TITLE
Include dotfiles when creating tar

### DIFF
--- a/image.go
+++ b/image.go
@@ -80,7 +80,7 @@ func (e *ExportedImage) TarLayer() error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/bash", "-c", "tar cvf ../layer.tar *")
+	cmd := exec.Command("sudo", "/bin/bash", "-c", "tar cvf ../layer.tar ./")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		println(string(out))


### PR DESCRIPTION
Small tweak that picks up files and dir's starting with "." during the tar generation step.

Thanks @jwilder for this project - very useful!