### PR TITLE
Support Labels

### DIFF
--- a/export.go
+++ b/export.go
@@ -66,6 +66,7 @@ type ContainerConfig struct {
 	Image           string
 	Volumes         map[string]struct{}
 	VolumesFrom     string
+	Labels		map[string]string
 }
 
 type Config struct {
@@ -93,6 +94,7 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
+	Labels		map[string]string
 }
 
 type LayerConfig struct {


### PR DESCRIPTION
Tested with a Dockerfile with "LABEL" instruction and verified that "docker inspect <image>" returns the label in both ContainerConfig and Config section.

Our downstream usage really needs this feature, so sending the PR to fix https://github.com/jwilder/docker-squash/issues/24.

Thanks!