### PR TITLE
Use 'sh' rather than 'bash' for compatibility with busybox and boot2docker

### DIFF
--- a/export.go
+++ b/export.go
@@ -531,7 +531,7 @@ func (e *Export) TarLayers(w io.Writer) error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/bash", "-c", "tar cOf  - *")
+	cmd := exec.Command("sudo", "/bin/sh", "-c", "tar cOf  - *")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err

--- a/image.go
+++ b/image.go
@@ -80,7 +80,7 @@ func (e *ExportedImage) TarLayer() error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/bash", "-c", "tar cvf ../layer.tar ./")
+	cmd := exec.Command("sudo", "/bin/sh", "-c", "tar cvf ../layer.tar ./")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		println(string(out))


### PR DESCRIPTION
By default, `boot2docker` and many other [JEOS](https://en.wikipedia.org/wiki/Just_enough_operating_system) container runtimes use `busybox` for a shell in order to save space.

While `busybox` can emulate several shells, `bash` is not one of them. Fortunately, plain old `sh` is.

Since the shell is only used to execute `tar` in a `sudo` context, this patch makes `docker-squash` compatible with being loaded onto a `boot2docker` image.