### PR TITLE
Support new docker manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 *.gz
+/docker-squash

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,2 +1,3 @@
 github.com/docker/docker 2606a2e4d3bf810ec82e373a6cd334e22e504e83
+github.com/docker/go-units 09dda9d4b0d748c57c14048906d3d094a58ec0c9
 github.com/bitly/go-simplejson aabad6e819789e569bd6aabf444c935aa9ba1e44

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,1 +1,2 @@
 github.com/docker/docker 2606a2e4d3bf810ec82e373a6cd334e22e504e83
+github.com/bitly/go-simplejson aabad6e819789e569bd6aabf444c935aa9ba1e44

--- a/export.go
+++ b/export.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/pkg/units"
+	"github.com/docker/go-units"
 )
 
 type TagInfo map[string]string

--- a/export.go
+++ b/export.go
@@ -557,7 +557,7 @@ func (e *Export) TarLayers(w io.Writer) error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/sh", "-c", "tar cOf  - *")
+	cmd := exec.Command("sudo", "/bin/sh", "-c", "gtar cOf  - *")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err

--- a/image.go
+++ b/image.go
@@ -80,7 +80,7 @@ func (e *ExportedImage) TarLayer() error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/sh", "-c", "tar cvf ../layer.tar ./")
+	cmd := exec.Command("sudo", "/bin/sh", "-c", "gtar cvf ../layer.tar ./")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		println(string(out))

--- a/main.go
+++ b/main.go
@@ -219,6 +219,10 @@ func main() {
 	} else {
 		debugf("Tarring new image to STDOUT\n")
 	}
+
+	// Update manifest
+	updateManifest(export, tag)
+
 	// bundle up the new image
 	err = export.TarLayers(ow)
 	if err != nil {
@@ -231,4 +235,20 @@ func main() {
 
 	signals <- os.Interrupt
 	wg.Wait()
+}
+
+func updateManifest(export *Export, tag string) {
+	manifestor, err := NewManifestor(export, tag)
+	if err != nil {
+		fatal(err)
+	}
+
+	manifestor.GenerateLayers()
+	manifestor.UpdateManifest()
+	manifestor.UpdateConfig()
+
+	err = manifestor.SaveChanges()
+	if err != nil {
+		fatal(err)
+	}
 }

--- a/manifest.go
+++ b/manifest.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"github.com/bitly/go-simplejson"
+	"io/ioutil"
+	"path/filepath"
+)
+
+type Layer struct {
+	Id      string
+	TarPath string
+	TarHash string
+}
+
+type JsonFile struct {
+	data *simplejson.Json
+	path string
+}
+
+type Manifestor struct {
+	basePath string
+	tag      string
+	layers   []Layer
+	export   *Export
+	manifest *JsonFile
+	config   *JsonFile
+}
+
+func NewManifestor(e *Export, tag string) (*Manifestor, error) {
+	manifest := &JsonFile{
+		path: filepath.Join(e.Path, "manifest.json"),
+	}
+
+	manifestContent, err := ioutil.ReadFile(manifest.path)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest.data, err = simplejson.NewJson(manifestContent)
+	if err != nil {
+		return nil, err
+	}
+
+	configPath, err := manifest.data.GetIndex(0).Get("Config").String()
+	if err != nil {
+		return nil, err
+	}
+
+	config := &JsonFile{
+		path: filepath.Join(e.Path, configPath),
+	}
+
+	configContent, err := ioutil.ReadFile(config.path)
+	if err != nil {
+		return nil, err
+	}
+
+	config.data, err = simplejson.NewJson(configContent)
+	if err != nil {
+		return nil, err
+	}
+
+	manifestor := &Manifestor{
+		tag:      tag,
+		basePath: e.Path,
+		manifest: manifest,
+		config:   config,
+		export:   e,
+	}
+
+	return manifestor, nil
+}
+
+func (m *Manifestor) GenerateLayers() {
+	current := m.export.Root()
+	order := []*ExportedImage{}
+	for {
+		order = append(order, current)
+		current = m.export.ChildOf(current.LayerConfig.Id)
+		if current == nil {
+			break
+		}
+	}
+
+	m.layers = []Layer{}
+
+	for i := 0; i < len(order); i++ {
+		data, err := ioutil.ReadFile(order[i].LayerTarPath)
+
+		if err != nil {
+			debug("Cannot read layer file: ", order[i].LayerTarPath, err)
+			return
+		}
+
+		sha := fmt.Sprintf("%x", sha256.Sum256(data))
+
+		layer := Layer{}
+		layer.Id = order[i].LayerConfig.Id
+		layer.TarPath = order[i].LayerConfig.Id + "/layer.tar"
+		layer.TarHash = sha
+
+		m.layers = append(m.layers, layer)
+	}
+}
+
+func (m *Manifestor) UpdateManifest() {
+	newLayers := []string{}
+	for i := 0; i < len(m.layers); i++ {
+		newLayers = append(newLayers, m.layers[i].TarPath)
+	}
+
+	// Replace the layers section
+	m.manifest.data.GetIndex(0).Set("Layers", newLayers)
+
+	if m.tag != "" {
+		m.manifest.data.GetIndex(0).Set("RepoTags", []string{m.tag})
+	}
+}
+
+func (m *Manifestor) UpdateConfig() {
+	newDiffs := []string{}
+	for i := 0; i < len(m.layers); i++ {
+		newDiffs = append(newDiffs, "sha256:"+m.layers[i].TarHash)
+	}
+
+	// Set new hashes and clear history
+	m.config.data.Get("rootfs").Set("diff_ids", newDiffs)
+	m.config.data.Set("history", []string{})
+}
+
+func (m *Manifestor) SaveChanges() error {
+	newManifest, err := m.manifest.data.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(m.manifest.path, newManifest, 0644)
+	if err != nil {
+		return err
+	}
+
+	newConfig, err := m.config.data.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(m.config.path, newConfig, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/osx_install.md
+++ b/osx_install.md
@@ -16,7 +16,7 @@ git clone https://github.com/jwilder/docker-squash.git
 Install the units package:
 
 ```bash
-go get github.com/docker/docker/pkg/units
+go get github.com/docker/go-units
 ```
 
 Build the binary:

--- a/osx_install.md
+++ b/osx_install.md
@@ -22,6 +22,7 @@ go get github.com/docker/go-units
 Build the binary:
 
 ```bash
+brew install gnu-tar
 GOBIN=$(pwd) make
 ```
 

--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 func extractTar(src, dest string) ([]byte, error) {
-	cmd := exec.Command("tar", "--same-owner", "--xattrs", "--overwrite",
+	cmd := exec.Command("gtar", "--same-owner", "--xattrs", "--overwrite",
 		"--preserve-permissions", "-xf", src, "-C", dest)
 	return cmd.CombinedOutput()
 }


### PR DESCRIPTION
This PR contains a _basic_ support for the new docker manifest file and allows importing or squashed images into docker 1.10+. 

Tested with docker daemon version 1.11

PS: This is VERY basic. Improvements would be greatly appreciated. 
