### PR TITLE
Remove hard-coded sudo in go files

### DIFF
--- a/export.go
+++ b/export.go
@@ -557,7 +557,7 @@ func (e *Export) TarLayers(w io.Writer) error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/sh", "-c", "tar cOf  - *")
+	cmd := exec.Command("/bin/sh", "-c", "tar cOf  - *")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err

--- a/image.go
+++ b/image.go
@@ -81,7 +81,7 @@ func (e *ExportedImage) TarLayer() error {
 	}
 	defer os.Chdir(cwd)
 
-	cmd := exec.Command("sudo", "/bin/sh", "-c", fmt.Sprintf("%s cvf ../layer.tar ./", TarCmd))
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf("%s cvf ../layer.tar ./", TarCmd))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		println(string(out))


### PR DESCRIPTION
Using `sudo` inside the code is not necessary and makes it difficult to use the tool in CI files